### PR TITLE
Revert to using cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,21 @@ runs:
       name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python-version }}
-        cache: 'pipenv'
+        python-version:  ${{ inputs.python-version }}
 
     - id: install-pipenv
       name: Install pipenv
-      run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      run: |
+        python -m pip install --upgrade --no-cache-dir pip
+        python -m pip install --no-cache-dir pipenv
       shell: bash
+
+    - id: cache-pipfile
+      name: Cache Pipfile
+      uses: actions/cache@v3
+      with:
+        path: ~/.local/share/virtualenvs
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
 
     - id: sync-pipfile
       name: Sync Pipfile


### PR DESCRIPTION
This reverts back to using `actions/cache` and upgrades it to `v3`.

As mentioned in #5, there were some Python errors using the action as it is implemented on `main`.